### PR TITLE
Remove obsolete DmrvApi reference

### DIFF
--- a/dmrv/readme.md
+++ b/dmrv/readme.md
@@ -1,0 +1,11 @@
+# DMrv Module
+
+This directory is reserved for experiments with the DMrv prototype.
+
+```
+# previously the instructions referenced ../tools/DmrvApi for additional utilities
+# but that project is no longer included in this repository.
+```
+
+DMrv functionality has been merged into the main project. You no longer
+need to clone `DmrvApi` separately.


### PR DESCRIPTION
## Summary
- add `dmrv/readme.md` describing DMrv prototype
- note that `DmrvApi` is no longer required

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c10a6d3c832f83a7e11bae588640